### PR TITLE
Include User-Agent to vuln scraping to bypass python UA block.

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -315,7 +315,12 @@ def extract_vulnerability_info_from_table(table):
 
 # Function to scrape vulnerabilities from a given page URL
 def scrape_vulnerabilities(page_url):
-    response = requests.get(page_url)
+    # The vulnerabilities page blocks the default python user agent
+    headers = {
+        'User-Agent': 'Moodle-Scanner'
+    }
+    
+    response = requests.get(page_url, headers=headers)
     vulnerabilities = []
     
     if response.status_code == 200:


### PR DESCRIPTION
Add custom User-Agent header for requests to scrape vulnerabilities to bypass the block on the default python user agent.

PoC

```
reelix@reelix-cachy  ~  curl -s "https://moodle.org/security/index.php?o=3&s=10&p=0" -H "User-Agent: python-requests/2.25.0" -I | grep HTTP
HTTP/2 403 
reelix@reelix-cachy  ~  curl -s "https://moodle.org/security/index.php?o=3&s=10&p=0" -H "User-Agent: Moodle-Scanner" -I | grep HTTP
HTTP/2 200
```